### PR TITLE
security: Phase 5 — Ingestion hardening (SSRF, sanitization, error leakage)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -14,8 +14,8 @@ class Settings(BaseSettings):
     API_PORT: int = 8000
     API_WORKERS: int = 4
 
-    # CORS
-    ALLOWED_ORIGINS: List[str] = ["*"]
+    # CORS — default to internal backend URL only; override via env var for dev
+    ALLOWED_ORIGINS: List[str] = ["http://ekitchen.railway.internal:8081"]
 
     # OpenAI
     OPENAI_API_KEY: str = ""

--- a/app/main.py
+++ b/app/main.py
@@ -114,9 +114,7 @@ async def auth_gate_middleware(request: Request, call_next):
         return JSONResponse(
             status_code=503,
             content={
-                "error": "Service unavailable - eKitchen authentication failed on startup",
-                "detail": _auth_error,
-                "hint": "Check EKITCHEN_BASE_URL, EKITCHEN_ADMIN_EMAIL, EKITCHEN_ADMIN_PASSWORD environment variables"
+                "error": "Service temporarily unavailable",
             }
         )
     

--- a/app/security.py
+++ b/app/security.py
@@ -1,0 +1,57 @@
+"""URL validation and SSRF protection."""
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+BLOCKED_HOSTS = {
+    'localhost', '127.0.0.1', '0.0.0.0', '::1',
+    'metadata.google.internal',
+    'instance-data',
+}
+
+BLOCKED_SUFFIXES = [
+    '.railway.internal',
+    '.local',
+    '.internal',
+]
+
+
+def is_safe_url(url: str) -> tuple[bool, str]:
+    """
+    Validate URL is safe for server-side requests (SSRF prevention).
+    Returns (is_safe, reason).
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return False, "Invalid URL format"
+
+    if parsed.scheme not in ('http', 'https'):
+        return False, f"Unsupported scheme: {parsed.scheme}"
+
+    if not parsed.netloc:
+        return False, "Missing host"
+
+    hostname = parsed.hostname
+    if not hostname:
+        return False, "Missing hostname"
+
+    if hostname in BLOCKED_HOSTS:
+        return False, f"Blocked host: {hostname}"
+
+    for suffix in BLOCKED_SUFFIXES:
+        if hostname.endswith(suffix):
+            return False, f"Internal domain blocked: {hostname}"
+
+    try:
+        resolved_ips = socket.getaddrinfo(hostname, None)
+        for _, _, _, _, addr in resolved_ips:
+            ip = ipaddress.ip_address(addr[0])
+            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                return False, f"Resolved to private/reserved IP: {ip}"
+            if addr[0] == '169.254.169.254':
+                return False, "Cloud metadata endpoint blocked"
+    except socket.gaierror:
+        return False, f"DNS resolution failed: {hostname}"
+
+    return True, "OK"

--- a/parsers/video.py
+++ b/parsers/video.py
@@ -14,6 +14,7 @@ from typing import Optional, Dict, Any, List
 from urllib.parse import urlparse
 
 from parsers.base import BaseParser, ParseResult
+from app.security import is_safe_url
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +123,11 @@ class VideoParser(BaseParser):
         return self._openai_client
 
     async def validate_url(self, url: str) -> bool:
-        """Check if URL is a supported video platform."""
+        """Check if URL is a supported video platform and safe from SSRF."""
+        is_safe, reason = is_safe_url(url)
+        if not is_safe:
+            logger.warning(f"URL blocked by SSRF check: {url} - {reason}")
+            return False
         return self._detect_platform(url) is not None
     
     def _detect_platform(self, url: str) -> Optional[str]:

--- a/parsers/website.py
+++ b/parsers/website.py
@@ -2,6 +2,7 @@
 Website recipe parser using recipe-scrapers library.
 Supports 200+ recipe websites.
 """
+import html
 import time
 import re
 from typing import Optional, Dict, Any
@@ -9,6 +10,7 @@ from urllib.parse import urlparse
 
 from recipe_scrapers import scrape_me
 from parsers.base import BaseParser, ParseResult
+from app.security import is_safe_url
 
 
 class WebsiteParser(BaseParser):
@@ -29,14 +31,15 @@ class WebsiteParser(BaseParser):
 
     async def validate_url(self, url: str) -> bool:
         """
-        Check if the URL is a valid HTTP/HTTPS URL.
+        Check if the URL is a valid HTTP/HTTPS URL and safe from SSRF.
         recipe-scrapers will handle site-specific validation.
         """
-        try:
-            parsed = urlparse(url)
-            return parsed.scheme in ('http', 'https') and bool(parsed.netloc)
-        except Exception:
+        is_safe, reason = is_safe_url(url)
+        if not is_safe:
+            import logging
+            logging.getLogger(__name__).warning(f"URL blocked by SSRF check: {url} - {reason}")
             return False
+        return True
 
     async def parse(self, url: str, **kwargs) -> ParseResult:
         """
@@ -64,12 +67,12 @@ class WebsiteParser(BaseParser):
             # Use recipe-scrapers to fetch and parse the recipe
             scraper = scrape_me(url)
 
-            # Extract all available data
+            # Extract all available data, sanitizing scraped text to remove HTML
             recipe_data = {
-                "name": self._safe_extract(scraper.title),
-                "description": self._safe_extract(scraper.description),
-                "ingredients": self._safe_extract(scraper.ingredients, default=[]),
-                "steps": self._safe_extract(scraper.instructions_list, default=[]),
+                "name": self._sanitize_text(self._safe_extract(scraper.title)),
+                "description": self._sanitize_text(self._safe_extract(scraper.description)),
+                "ingredients": self._sanitize_list(self._safe_extract(scraper.ingredients, default=[])),
+                "steps": self._sanitize_list(self._safe_extract(scraper.instructions_list, default=[])),
                 "servings": self._extract_servings(scraper),
                 "prep_time_minutes": self._extract_time_minutes(scraper.prep_time),
                 "cook_time_minutes": self._extract_time_minutes(scraper.cook_time),
@@ -113,6 +116,21 @@ class WebsiteParser(BaseParser):
                 error_message=str(e),
                 parser_name=self.parser_name
             )
+
+    def _sanitize_text(self, text: Any) -> Any:
+        """Strip HTML tags and decode entities from scraped text."""
+        if not isinstance(text, str):
+            return text
+        clean = re.sub(r'<[^>]+>', '', text)
+        clean = html.unescape(clean)
+        clean = re.sub(r'\s+', ' ', clean).strip()
+        return clean
+
+    def _sanitize_list(self, items: Any) -> Any:
+        """Sanitize a list of strings."""
+        if not isinstance(items, list):
+            return items
+        return [self._sanitize_text(item) for item in items if item]
 
     def _safe_extract(self, func_or_value, default: Any = None) -> Any:
         """


### PR DESCRIPTION
## Summary
- Restrict CORS from wildcard `*` to internal backend URL only (`http://ekitchen.railway.internal:8081`) (H2)
- New `app/security.py` module: SSRF protection blocking private IPs, loopback, `.railway.internal`, GCP/AWS metadata endpoints — applied to both `website.py` and `video.py` URL validation (M6)
- Sanitize scraped recipe data (name, description, ingredients, steps) to strip HTML tags and decode entities before storage (M3)
- Remove internal auth error details from 503 response — now returns generic `{"error": "Service temporarily unavailable"}` only (M4)

## Security findings addressed
`H2` — CORS wildcard | `M3` — Unsanitized scraped data | `M4` — Internal error leakage | `M6` — SSRF vulnerability

## Railway action needed after merge
Set `ALLOWED_ORIGINS=["http://ekitchen.railway.internal:8081"]` in Railway ingestion env vars to override the default.

## Test plan
- [ ] Valid recipe URLs (AllRecipes, FoodNetwork, etc.) still parse successfully
- [ ] `http://169.254.169.254` rejected by SSRF check
- [ ] `http://postgres.railway.internal:5432` rejected
- [ ] `http://127.0.0.1` rejected
- [ ] Scraped recipe data contains no HTML tags or entities
- [ ] 503 response shows only generic message (not internal auth details)

🤖 Generated with [Claude Code](https://claude.com/claude-code)